### PR TITLE
Added warning to get/fetch user to warn devs not to use them in the future

### DIFF
--- a/discord/client.py
+++ b/discord/client.py
@@ -804,6 +804,7 @@ class Client:
         """
         return self._connection._get_guild(id)
 
+    @utils.deprecated("'Member' objects")
     def get_user(self, id):
         """Returns a user with the given ID.
 
@@ -1353,6 +1354,7 @@ class Client:
             data['rpc_origins'] = None
         return AppInfo(self._connection, data)
 
+    @utils.deprecated("'Member' objects")
     async def fetch_user(self, user_id):
         """|coro|
 


### PR DESCRIPTION
…
## Summary

Added a Python warning to all the `discord.User`-generating functions. Used the discord.py `@utils.deprecated` decorator. 

There should be no change in functionality.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
